### PR TITLE
[WarpBuild]: shift workflows to warp-ubuntu-latest-arm64-4x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,7 @@ on:
 jobs:
   run-ci:
     name: Run Type Check & Linters
-    runs-on: ubuntu-latest
-
+    runs-on: warp-ubuntu-latest-arm64-4x
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,8 +4,7 @@ on: workflow_dispatch
 
 jobs:
   release:
-    runs-on: ubuntu-latest
-
+    runs-on: warp-ubuntu-latest-arm64-4x
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION

## Ready to Warp! 🚀


> [!IMPORTANT]
> We noticed that this repository is public. Please make sure to allow WarpBuild runners to be used by public repositories:
> 1. Go to your organization's [default runner settings page](https://github.com/organizations/subtopia-algo/settings/actions/runner-groups/1).
> 2. Check `Allow public repositories`.
>
> For more information, please refer our [documentation](https://docs.warpbuild.com/public-repos)


This PR was raised by WarpBuild to shift the following workflow(s) to the `warp-ubuntu-latest-arm64-4x` runner.

1. [CI](https://github.com/subtopia-algo/use-wallet/blob/main/.github/workflows/ci.yml)
1. [Release & Publish to NPM](https://github.com/subtopia-algo/use-wallet/blob/main/.github/workflows/release.yml)

Please review the changes in this PR and merge when ready. You can see the status at your [dashboard](https://app.warpbuild.com).

> [!NOTE]
> **All** the jobs in the workflows are shifted to the chosen runner. If you want to shift only a few jobs, please change the values manually in the workflow files.
----
Switches to using fast runners provisioned on [warpbuild.com](https://warpbuild.com).
